### PR TITLE
Endpoint for adding new events for main judge

### DIFF
--- a/server/src/gateways/judges.gateway.ts
+++ b/server/src/gateways/judges.gateway.ts
@@ -156,8 +156,8 @@ export class JudgesGateway {
     @MessageBody('fightId') fightId: string,
     @MessageBody('judgeId') judgeId: string,
     @MessageBody('events') events: Event[],
-    @MessageBody('playerId') playerId: string,
-    @MessageBody('playerPoints') playerPoints: number,
+    @MessageBody('redPlayerPoints') redPlayerPoints: number,
+    @MessageBody('bluePlayerPoints') bluePlayerPoints: number,
     @ConnectedSocket() client: Socket,
   ) {
     if (!this.fightsService.getFight(fightId)) {
@@ -171,8 +171,8 @@ export class JudgesGateway {
     const status = this.fightsService.newEvents(
       fightId,
       events,
-      playerId,
-      playerPoints,
+      redPlayerPoints,
+      bluePlayerPoints,
     );
     const fight = this.fightsService.getFight(fightId);
 

--- a/server/src/interfaces/event.interface.ts
+++ b/server/src/interfaces/event.interface.ts
@@ -1,5 +1,4 @@
 export interface Event {
   id: string;
-  sequenceIds: string[];
-  points: number;
+  playerColor: string;
 }

--- a/server/src/interfaces/fight.interface.ts
+++ b/server/src/interfaces/fight.interface.ts
@@ -1,26 +1,21 @@
-import { Event } from './event.interface.js';
 import { Socket } from 'socket.io';
 import { Timer } from '../classes/timer/timer.class.js';
+import { Event } from './event.interface';
 
 export interface Fight {
   id: string;
+
   state: FightState;
-
-  mainJudgeId: string;
-  redJudgeId: string;
-  blueJudgeId: string;
-
-  mainJudgeSocket: Socket;
-  redJudgeSocket: Socket;
-  blueJudgeSocket: Socket;
-
-  redPlayerId: string;
-  bluePlayerId: string;
-
-  redEventsHistory: Event[];
-  blueEventsHistory: Event[];
-
   timer: Timer;
+
+  mainJudge: JudgeState;
+  redJudge: JudgeState;
+  blueJudge: JudgeState;
+
+  redPlayer: PlayerState;
+  bluePlayer: PlayerState;
+
+  eventsHistory: Event[];
 }
 
 export enum FightState {
@@ -28,4 +23,14 @@ export enum FightState {
   Running,
   Paused,
   Finished,
+}
+
+export interface JudgeState {
+  id: string;
+  socket: Socket;
+}
+
+export interface PlayerState {
+  id: string;
+  points: number;
 }

--- a/server/src/interfaces/new-events-response.ts
+++ b/server/src/interfaces/new-events-response.ts
@@ -1,0 +1,9 @@
+import { Event } from './event.interface';
+import { Response } from './response.interface';
+import { PlayerState } from './fight.interface';
+
+export interface NewEventsResponse extends Response {
+  allEvents: Event[];
+  redPlayer: PlayerState;
+  bluePlayer: PlayerState;
+}

--- a/server/src/services/fights.service.ts
+++ b/server/src/services/fights.service.ts
@@ -176,8 +176,8 @@ export class FightsService {
   newEvents(
     fightId: string,
     events: Event[],
-    playerId: string,
-    playerPoints: number,
+    redPlayerPoints: number,
+    bluePlayerPoints: number,
   ): ResponseStatus {
     const fight = this.fights.get(fightId);
 
@@ -187,15 +187,14 @@ export class FightsService {
       return ResponseStatus.BadRequest;
     }
 
-    if (playerId == fight.redPlayer.id) {
-      fight.redPlayer.points += playerPoints;
-    } else if (playerId == fight.blueJudge.id) {
-      fight.bluePlayer.points += playerPoints;
-    } else {
+    if (redPlayerPoints < 0 || bluePlayerPoints < 0) {
       return ResponseStatus.BadRequest;
     }
 
+    fight.redPlayer.points += redPlayerPoints;
+    fight.bluePlayer.points += bluePlayerPoints;
     fight.eventsHistory = fight.eventsHistory.concat(events);
+
     return ResponseStatus.OK;
   }
 }

--- a/server/src/services/fights.service.ts
+++ b/server/src/services/fights.service.ts
@@ -3,6 +3,7 @@ import { Socket } from 'socket.io';
 import { Timer } from '../classes/timer/timer.class';
 import { Fight, FightState } from '../interfaces/fight.interface';
 import { ResponseStatus } from '../interfaces/response.interface';
+import { Event } from '../interfaces/event.interface';
 
 @Injectable()
 export class FightsService {
@@ -12,22 +13,31 @@ export class FightsService {
     const fight: Fight = {
       id: 'mockup',
       state: FightState.Scheduled,
-
-      mainJudgeId: 'main',
-      redJudgeId: 'red',
-      blueJudgeId: 'blue',
-
-      mainJudgeSocket: null,
-      redJudgeSocket: null,
-      blueJudgeSocket: null,
-
-      redPlayerId: 'player1',
-      bluePlayerId: 'player2',
-
-      redEventsHistory: [],
-      blueEventsHistory: [],
-
       timer: new Timer(1),
+
+      mainJudge: {
+        id: 'main',
+        socket: null,
+      },
+      redJudge: {
+        id: 'red',
+        socket: null,
+      },
+      blueJudge: {
+        id: 'blue',
+        socket: null,
+      },
+
+      redPlayer: {
+        id: 'player1',
+        points: 0,
+      },
+      bluePlayer: {
+        id: 'player2',
+        points: 0,
+      },
+
+      eventsHistory: [],
     };
     this.newFight(fight);
   }
@@ -47,7 +57,7 @@ export class FightsService {
       return false;
     }
 
-    return [fight.mainJudgeId, fight.redJudgeId, fight.blueJudgeId].includes(
+    return [fight.mainJudge.id, fight.redJudge.id, fight.blueJudge.id].includes(
       judgeId,
     );
   }
@@ -59,7 +69,7 @@ export class FightsService {
       return false;
     }
 
-    return judgeId == fight.mainJudgeId;
+    return judgeId == fight.mainJudge.id;
   }
 
   addJudge(fightId: string, judgeId: string, socket: Socket): ResponseStatus {
@@ -68,23 +78,23 @@ export class FightsService {
     if (fight == undefined) {
       return ResponseStatus.NotFound;
     } else if (
-      (judgeId == fight.mainJudgeId &&
-        fight.mainJudgeSocket != null &&
-        fight.mainJudgeSocket != socket) ||
-      (judgeId == fight.redJudgeId &&
-        fight.redJudgeSocket != null &&
-        fight.redJudgeSocket != socket) ||
-      (judgeId == fight.blueJudgeId &&
-        fight.blueJudgeSocket != null &&
-        fight.blueJudgeSocket != socket)
+      (judgeId == fight.mainJudge.id &&
+        fight.mainJudge.socket != null &&
+        fight.mainJudge.socket != socket) ||
+      (judgeId == fight.redJudge.id &&
+        fight.redJudge.socket != null &&
+        fight.redJudge.socket != socket) ||
+      (judgeId == fight.blueJudge.id &&
+        fight.blueJudge.socket != null &&
+        fight.blueJudge.socket != socket)
     ) {
       return ResponseStatus.BadRequest;
-    } else if (judgeId == fight.mainJudgeId) {
-      fight.mainJudgeSocket = socket;
-    } else if (judgeId == fight.redJudgeId) {
-      fight.redJudgeSocket = socket;
-    } else if (judgeId == fight.blueJudgeId) {
-      fight.blueJudgeSocket = socket;
+    } else if (judgeId == fight.mainJudge.id) {
+      fight.mainJudge.socket = socket;
+    } else if (judgeId == fight.redJudge.id) {
+      fight.redJudge.socket = socket;
+    } else if (judgeId == fight.blueJudge.id) {
+      fight.blueJudge.socket = socket;
     } else {
       return ResponseStatus.Unauthorized;
     }
@@ -98,9 +108,9 @@ export class FightsService {
     if (fight == undefined) {
       return ResponseStatus.NotFound;
     } else if (
-      fight.mainJudgeSocket == null ||
-      fight.redJudgeSocket == null ||
-      fight.blueJudgeSocket == null
+      fight.mainJudge.socket == null ||
+      fight.redJudge.socket == null ||
+      fight.blueJudge.socket == null
     ) {
       return ResponseStatus.NotReady;
     } else if (fight.state != FightState.Scheduled) {
@@ -161,5 +171,31 @@ export class FightsService {
       return ResponseStatus.OK;
     }
     return ResponseStatus.BadRequest;
+  }
+
+  newEvents(
+    fightId: string,
+    events: Event[],
+    playerId: string,
+    playerPoints: number,
+  ): ResponseStatus {
+    const fight = this.fights.get(fightId);
+
+    if (fight == undefined) {
+      return ResponseStatus.NotFound;
+    } else if (![FightState.Running, FightState.Paused].includes(fight.state)) {
+      return ResponseStatus.BadRequest;
+    }
+
+    if (playerId == fight.redPlayer.id) {
+      fight.redPlayer.points += playerPoints;
+    } else if (playerId == fight.blueJudge.id) {
+      fight.bluePlayer.points += playerPoints;
+    } else {
+      return ResponseStatus.BadRequest;
+    }
+
+    fight.eventsHistory = fight.eventsHistory.concat(events);
+    return ResponseStatus.OK;
   }
 }

--- a/server/test/gateways/judges.gateway.spec.ts
+++ b/server/test/gateways/judges.gateway.spec.ts
@@ -468,12 +468,12 @@ describe('JudgesGateway', () => {
 
     describe('newEvents', () => {
       let events: Event[];
-      let playerId: string;
-      let playerPoints: number;
+      let redPlayerPoints: number;
+      let bluePlayerPoints: number;
 
       beforeEach(() => {
-        playerId = fight.redPlayer.id;
-        playerPoints = 2;
+        redPlayerPoints = 2;
+        bluePlayerPoints = 1;
 
         events = [
           { id: 'a', playerColor: 'red' },
@@ -487,8 +487,8 @@ describe('JudgesGateway', () => {
           fightId: 'test 123',
           judgeId: fight.mainJudge.id,
           events: events,
-          playerId: playerId,
-          playerPoints: playerPoints,
+          redPlayerPoints: redPlayerPoints,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>
@@ -504,8 +504,8 @@ describe('JudgesGateway', () => {
           fightId: fight.id,
           judgeId: fight.redJudge.id,
           events: events,
-          playerId: playerId,
-          playerPoints: playerPoints,
+          redPlayerPoints: redPlayerPoints,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>
@@ -516,13 +516,13 @@ describe('JudgesGateway', () => {
         );
       });
 
-      it('should not add events for random player', async () => {
+      it('should not add events with negative number of points', async () => {
         wsMain.emit('newEvents', {
           fightId: fight.id,
           judgeId: fight.mainJudge.id,
           events: events,
-          playerId: 'test 123',
-          playerPoints: playerPoints,
+          redPlayerPoints: -1,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>
@@ -538,15 +538,15 @@ describe('JudgesGateway', () => {
           fightId: fight.id,
           judgeId: fight.mainJudge.id,
           events: events,
-          playerId: playerId,
-          playerPoints: playerPoints,
+          redPlayerPoints: redPlayerPoints,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>
           wsMain.on('newEvents', (data) => {
             expect(data.status).toBe(ResponseStatus.OK);
             expect(fight.redPlayer.points).toBe(2);
-            expect(fight.bluePlayer.points).toBe(0);
+            expect(fight.bluePlayer.points).toBe(1);
             expect(fight.eventsHistory).toStrictEqual(events);
             resolve();
           }),
@@ -563,15 +563,15 @@ describe('JudgesGateway', () => {
           fightId: fight.id,
           judgeId: fight.mainJudge.id,
           events: events,
-          playerId: playerId,
-          playerPoints: playerPoints,
+          redPlayerPoints: redPlayerPoints,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>
           wsMain.on('newEvents', (data) => {
             expect(data.status).toBe(ResponseStatus.OK);
             expect(fight.redPlayer.points).toBe(2 + 2);
-            expect(fight.bluePlayer.points).toBe(0);
+            expect(fight.bluePlayer.points).toBe(1 + 1);
             expect(fight.eventsHistory).toStrictEqual(events.concat(events));
             resolve();
           }),
@@ -588,8 +588,8 @@ describe('JudgesGateway', () => {
           fightId: fight.id,
           judgeId: fight.mainJudge.id,
           events: events,
-          playerId: playerId,
-          playerPoints: playerPoints,
+          redPlayerPoints: redPlayerPoints,
+          bluePlayerPoints: bluePlayerPoints,
         });
 
         await new Promise<void>((resolve) =>

--- a/server/test/gateways/judges.gateway.spec.ts
+++ b/server/test/gateways/judges.gateway.spec.ts
@@ -6,6 +6,7 @@ import { JudgesGateway } from '../../src/gateways/judges.gateway';
 import { FightsService } from '../../src/services/fights.service';
 import { Timer } from '../../src/classes/timer/timer.class';
 import { INestApplication } from '@nestjs/common';
+import { Event } from '../../src/interfaces/event.interface';
 
 async function createNestApp(...providers): Promise<INestApplication> {
   const testingModule = await Test.createTestingModule({
@@ -43,22 +44,31 @@ describe('JudgesGateway', () => {
     fight = {
       id: 'mockup',
       state: FightState.Scheduled,
-
-      mainJudgeId: 'main',
-      redJudgeId: 'red',
-      blueJudgeId: 'blue',
-
-      mainJudgeSocket: null,
-      redJudgeSocket: null,
-      blueJudgeSocket: null,
-
-      redPlayerId: 'player1',
-      bluePlayerId: 'player2',
-
-      redEventsHistory: [],
-      blueEventsHistory: [],
-
       timer: new Timer(1),
+
+      mainJudge: {
+        id: 'main',
+        socket: null,
+      },
+      redJudge: {
+        id: 'red',
+        socket: null,
+      },
+      blueJudge: {
+        id: 'blue',
+        socket: null,
+      },
+
+      redPlayer: {
+        id: 'player1',
+        points: 0,
+      },
+      bluePlayer: {
+        id: 'player2',
+        points: 0,
+      },
+
+      eventsHistory: [],
     };
 
     app.get(FightsService).newFight(fight);
@@ -75,7 +85,7 @@ describe('JudgesGateway', () => {
       ws = io('http://localhost:3001');
       ws.emit('join', {
         fightId: fight.id,
-        judgeId: fight.mainJudgeId,
+        judgeId: fight.mainJudge.id,
       });
 
       await new Promise<void>((resolve) =>
@@ -90,7 +100,7 @@ describe('JudgesGateway', () => {
       ws = io('http://localhost:3001');
       ws.emit('join', {
         fightId: fight.id,
-        judgeId: fight.redJudgeId,
+        judgeId: fight.redJudge.id,
       });
 
       await new Promise<void>((resolve) =>
@@ -120,7 +130,7 @@ describe('JudgesGateway', () => {
       ws = io('http://localhost:3001');
       ws.emit('join', {
         fightId: 'test 123',
-        judgeId: fight.mainJudgeId,
+        judgeId: fight.mainJudge.id,
       });
 
       await new Promise<void>((resolve) =>
@@ -138,12 +148,12 @@ describe('JudgesGateway', () => {
     let wsMain, wsRed, wsBlue;
 
     beforeEach(async () => {
-      fight.mainJudgeSocket = null;
-      wsMain = await joinNewJudge(fight.id, fight.mainJudgeId);
-      fight.redJudgeSocket = null;
-      wsRed = await joinNewJudge(fight.id, fight.redJudgeId);
-      fight.blueJudgeSocket = null;
-      wsBlue = await joinNewJudge(fight.id, fight.blueJudgeId);
+      fight.mainJudge.socket = null;
+      wsMain = await joinNewJudge(fight.id, fight.mainJudge.id);
+      fight.redJudge.socket = null;
+      wsRed = await joinNewJudge(fight.id, fight.redJudge.id);
+      fight.blueJudge.socket = null;
+      wsBlue = await joinNewJudge(fight.id, fight.blueJudge.id);
     });
 
     afterEach(() => {
@@ -156,7 +166,7 @@ describe('JudgesGateway', () => {
       it('should not start random fight', async () => {
         wsMain.emit('startFight', {
           fightId: 'test 123',
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -168,11 +178,11 @@ describe('JudgesGateway', () => {
       });
 
       it('should not start fight without all judges', async () => {
-        fight.blueJudgeSocket = null;
+        fight.blueJudge.socket = null;
 
         wsMain.emit('startFight', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -186,7 +196,7 @@ describe('JudgesGateway', () => {
       it('should not start fight if not main judge', async () => {
         wsRed.emit('startFight', {
           fightId: fight.id,
-          judgeId: fight.redJudgeId,
+          judgeId: fight.redJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -200,7 +210,7 @@ describe('JudgesGateway', () => {
       it('should start ready fight', async () => {
         wsMain.emit('startFight', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         for (const ws of [wsMain, wsRed, wsBlue]) {
@@ -220,7 +230,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('startFight', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -236,7 +246,7 @@ describe('JudgesGateway', () => {
       it('should not finish random fight', async () => {
         wsMain.emit('finishFight', {
           fightId: 'test 123',
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -252,7 +262,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('finishFight', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -268,7 +278,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('finishFight', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         for (const ws of [wsMain, wsRed, wsBlue]) {
@@ -298,7 +308,7 @@ describe('JudgesGateway', () => {
 
         wsRed.emit('resumeTimer', {
           fightId: fight.id,
-          judgeId: fight.redJudgeId,
+          judgeId: fight.redJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -316,7 +326,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('resumeTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         for (const ws of [wsMain, wsRed, wsBlue]) {
@@ -334,7 +344,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('resumeTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         await new Promise<void>((resolve) =>
@@ -351,7 +361,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('resumeTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
         });
 
         for (const ws of [wsMain, wsRed, wsBlue]) {
@@ -380,7 +390,7 @@ describe('JudgesGateway', () => {
 
         wsRed.emit('pauseTimer', {
           fightId: fight.id,
-          judgeId: fight.redJudgeId,
+          judgeId: fight.redJudge.id,
           exactPauseTimeInMillis: exactPauseTimeInMillis,
         });
 
@@ -399,7 +409,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('pauseTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
           exactPauseTimeInMillis: exactPauseTimeInMillis,
         });
 
@@ -421,7 +431,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('pauseTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
           exactPauseTimeInMillis: exactPauseTimeInMillis,
         });
 
@@ -440,7 +450,7 @@ describe('JudgesGateway', () => {
 
         wsMain.emit('pauseTimer', {
           fightId: fight.id,
-          judgeId: fight.mainJudgeId,
+          judgeId: fight.mainJudge.id,
           exactPauseTimeInMillis: exactPauseTimeInMillis,
         });
 
@@ -453,6 +463,141 @@ describe('JudgesGateway', () => {
             }),
           );
         }
+      });
+    });
+
+    describe('newEvents', () => {
+      let events: Event[];
+      let playerId: string;
+      let playerPoints: number;
+
+      beforeEach(() => {
+        playerId = fight.redPlayer.id;
+        playerPoints = 2;
+
+        events = [
+          { id: 'a', playerColor: 'red' },
+          { id: 'b', playerColor: 'blue' },
+          { id: 'a', playerColor: 'red' },
+        ];
+      });
+
+      it('should not add events to random fight', async () => {
+        wsMain.emit('newEvents', {
+          fightId: 'test 123',
+          judgeId: fight.mainJudge.id,
+          events: events,
+          playerId: playerId,
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.NotFound);
+            resolve();
+          }),
+        );
+      });
+
+      it('should not add events when not main judge', async () => {
+        wsMain.emit('newEvents', {
+          fightId: fight.id,
+          judgeId: fight.redJudge.id,
+          events: events,
+          playerId: playerId,
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.Unauthorized);
+            resolve();
+          }),
+        );
+      });
+
+      it('should not add events for random player', async () => {
+        wsMain.emit('newEvents', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+          events: events,
+          playerId: 'test 123',
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.BadRequest);
+            resolve();
+          }),
+        );
+      });
+
+      it('should add events to started fight', async () => {
+        wsMain.emit('newEvents', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+          events: events,
+          playerId: playerId,
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.OK);
+            expect(fight.redPlayer.points).toBe(2);
+            expect(fight.bluePlayer.points).toBe(0);
+            expect(fight.eventsHistory).toStrictEqual(events);
+            resolve();
+          }),
+        );
+      });
+
+      it('should add events to paused fight', async () => {
+        wsMain.emit('pauseFight', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+        });
+
+        wsMain.emit('newEvents', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+          events: events,
+          playerId: playerId,
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.OK);
+            expect(fight.redPlayer.points).toBe(2 + 2);
+            expect(fight.bluePlayer.points).toBe(0);
+            expect(fight.eventsHistory).toStrictEqual(events.concat(events));
+            resolve();
+          }),
+        );
+      });
+
+      it('should not add events to finished fight', async () => {
+        wsMain.emit('finishFight', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+        });
+
+        wsMain.emit('newEvents', {
+          fightId: fight.id,
+          judgeId: fight.mainJudge.id,
+          events: events,
+          playerId: playerId,
+          playerPoints: playerPoints,
+        });
+
+        await new Promise<void>((resolve) =>
+          wsMain.on('newEvents', (data) => {
+            expect(data.status).toBe(ResponseStatus.BadRequest);
+            resolve();
+          }),
+        );
       });
     });
   });

--- a/server/test/services/fights.service.spec.ts
+++ b/server/test/services/fights.service.spec.ts
@@ -286,8 +286,8 @@ describe('FightsService', () => {
 
   describe('newEvents', () => {
     let events: Event[];
-    const playerId = fight.redPlayer.id;
-    const playerPoints = 2;
+    const redPlayerPoints = 2;
+    const bluePlayerPoints = 1;
 
     beforeEach(() => {
       fight.timer = new Timer(1);
@@ -308,7 +308,12 @@ describe('FightsService', () => {
 
     it('should not add events for random fight', () => {
       expect(
-        fightService.newEvents('test 123', events, playerId, playerPoints),
+        fightService.newEvents(
+          'test 123',
+          events,
+          redPlayerPoints,
+          bluePlayerPoints,
+        ),
       ).toBe(ResponseStatus.NotFound);
 
       expect(fight.redPlayer.points).toBe(0);
@@ -319,7 +324,12 @@ describe('FightsService', () => {
     it('should not add events for scheduled fight', () => {
       fight.state = FightState.Scheduled;
       expect(
-        fightService.newEvents(fight.id, events, playerId, playerPoints),
+        fightService.newEvents(
+          fight.id,
+          events,
+          redPlayerPoints,
+          bluePlayerPoints,
+        ),
       ).toBe(ResponseStatus.BadRequest);
 
       expect(fight.redPlayer.points).toBe(0);
@@ -327,9 +337,9 @@ describe('FightsService', () => {
       expect(fight.eventsHistory).toStrictEqual([]);
     });
 
-    it('should not add events for random player', () => {
+    it('should not add events with negative number of points', () => {
       expect(
-        fightService.newEvents(fight.id, events, 'test 123', playerPoints),
+        fightService.newEvents(fight.id, events, -1, bluePlayerPoints),
       ).toBe(ResponseStatus.BadRequest);
 
       expect(fight.redPlayer.points).toBe(0);
@@ -340,7 +350,12 @@ describe('FightsService', () => {
     it('should not add events for finished fight', () => {
       fight.state = FightState.Finished;
       expect(
-        fightService.newEvents(fight.id, events, playerId, playerPoints),
+        fightService.newEvents(
+          fight.id,
+          events,
+          redPlayerPoints,
+          bluePlayerPoints,
+        ),
       ).toBe(ResponseStatus.BadRequest);
 
       expect(fight.redPlayer.points).toBe(0);
@@ -350,11 +365,16 @@ describe('FightsService', () => {
 
     it('should add new events for running fight', () => {
       expect(
-        fightService.newEvents(fight.id, events, playerId, playerPoints),
+        fightService.newEvents(
+          fight.id,
+          events,
+          redPlayerPoints,
+          bluePlayerPoints,
+        ),
       ).toBe(ResponseStatus.OK);
 
       expect(fight.redPlayer.points).toBe(2);
-      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(1);
       expect(fight.eventsHistory).toStrictEqual(events);
 
       fight.redPlayer.points = 0;
@@ -364,11 +384,16 @@ describe('FightsService', () => {
 
     it('should add new events for paused fight', () => {
       expect(
-        fightService.newEvents(fight.id, events, playerId, playerPoints),
+        fightService.newEvents(
+          fight.id,
+          events,
+          redPlayerPoints,
+          bluePlayerPoints,
+        ),
       ).toBe(ResponseStatus.OK);
 
       expect(fight.redPlayer.points).toBe(2);
-      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(1);
       expect(fight.eventsHistory).toStrictEqual(events);
 
       fight.redPlayer.points = 0;

--- a/server/test/services/fights.service.spec.ts
+++ b/server/test/services/fights.service.spec.ts
@@ -160,14 +160,12 @@ describe('FightsService', () => {
       fightService.addJudge(fight.id, fight.mainJudge.id, socket as any);
       fightService.addJudge(fight.id, fight.redJudge.id, socket as any);
       expect(fightService.startFight(fight.id)).toBe(ResponseStatus.NotReady);
-      // socket.disconnect();
     });
 
     it('should start ready fight after missing judge joined', () => {
       const socket = manager.socket('/');
       fightService.addJudge(fight.id, fight.blueJudge.id, socket as any);
       expect(fightService.startFight(fight.id)).toBe(ResponseStatus.OK);
-      // socket.disconnect();
     });
 
     it('should not start not running fight', () => {

--- a/server/test/services/fights.service.spec.ts
+++ b/server/test/services/fights.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { FightsService } from '../../src/services/fights.service';
 import { Fight, FightState } from '../../src/interfaces/fight.interface';
 import { ResponseStatus } from '../../src/interfaces/response.interface';
+import { Event } from '../../src/interfaces/event.interface';
 import { Manager } from 'socket.io-client';
 import { Timer } from '../../src/classes/timer/timer.class';
 
@@ -9,25 +10,35 @@ describe('FightsService', () => {
   let app: TestingModule;
   let fightService: FightsService;
   let manager: Manager;
+
   const fight: Fight = {
     id: 'mockup',
     state: FightState.Scheduled,
-
-    mainJudgeId: 'main',
-    redJudgeId: 'red',
-    blueJudgeId: 'blue',
-
-    mainJudgeSocket: null,
-    redJudgeSocket: null,
-    blueJudgeSocket: null,
-
-    redPlayerId: 'player1',
-    bluePlayerId: 'player2',
-
-    redEventsHistory: [],
-    blueEventsHistory: [],
-
     timer: new Timer(1),
+
+    mainJudge: {
+      id: 'main',
+      socket: null,
+    },
+    redJudge: {
+      id: 'red',
+      socket: null,
+    },
+    blueJudge: {
+      id: 'blue',
+      socket: null,
+    },
+
+    redPlayer: {
+      id: 'player1',
+      points: 0,
+    },
+    bluePlayer: {
+      id: 'player2',
+      points: 0,
+    },
+
+    eventsHistory: [],
   };
 
   beforeAll(async () => {
@@ -55,45 +66,45 @@ describe('FightsService', () => {
   });
 
   describe('isJudge', () => {
-    it('should check if given judgeId belongs to main judge', () => {
-      expect(fightService.isJudge(fight.id, fight.mainJudgeId)).toBeTruthy();
+    it('should check if given Judge.id belongs to main judge', () => {
+      expect(fightService.isJudge(fight.id, fight.mainJudge.id)).toBeTruthy();
     });
 
-    it('should check if given judgeId belongs to red judge', () => {
-      expect(fightService.isJudge(fight.id, fight.redJudgeId)).toBeTruthy();
+    it('should check if given Judge.id belongs to red judge', () => {
+      expect(fightService.isJudge(fight.id, fight.redJudge.id)).toBeTruthy();
     });
 
-    it('should check if given judgeId not belongs to random judge', () => {
+    it('should check if given Judge.id not belongs to random judge', () => {
       expect(fightService.isJudge(fight.id, 'test 123')).not.toBeTruthy();
     });
 
-    it('should check if given judgeId not belongs to random fight', () => {
+    it('should check if given Judge.id not belongs to random fight', () => {
       expect(
-        fightService.isJudge('test 123', fight.mainJudgeId),
+        fightService.isJudge('test 123', fight.mainJudge.id),
       ).not.toBeTruthy();
     });
   });
 
   describe('isMainJudge', () => {
-    it('should check if given judgeId belongs to the main judge', () => {
+    it('should check if given Judge.id belongs to the main judge', () => {
       expect(
-        fightService.isMainJudge(fight.id, fight.mainJudgeId),
+        fightService.isMainJudge(fight.id, fight.mainJudge.id),
       ).toBeTruthy();
     });
 
-    it('should check if given judgeId not belongs to the main judge', () => {
+    it('should check if given Judge.id not belongs to the main judge', () => {
       expect(
-        fightService.isMainJudge(fight.id, fight.redJudgeId),
+        fightService.isMainJudge(fight.id, fight.redJudge.id),
       ).not.toBeTruthy();
     });
 
-    it('should check if random judgeId not belongs to the main judge', () => {
+    it('should check if random Judge.id not belongs to the main judge', () => {
       expect(fightService.isMainJudge(fight.id, 'test 123')).not.toBeTruthy();
     });
 
-    it('should check if main judgeId not belongs to the random fight', () => {
+    it('should check if main Judge.id not belongs to the random fight', () => {
       expect(
-        fightService.isMainJudge('test 123', fight.mainJudgeId),
+        fightService.isMainJudge('test 123', fight.mainJudge.id),
       ).not.toBeTruthy();
     });
   });
@@ -106,13 +117,13 @@ describe('FightsService', () => {
     });
 
     it('should not be able to join random fight', () => {
-      expect(fightService.addJudge('test 123', fight.mainJudgeId, null)).toBe(
+      expect(fightService.addJudge('test 123', fight.mainJudge.id, null)).toBe(
         ResponseStatus.NotFound,
       );
     });
 
     it('red judge should be able to join fight and save his/her socket', () => {
-      expect(fightService.addJudge(fight.id, fight.redJudgeId, null)).toBe(
+      expect(fightService.addJudge(fight.id, fight.redJudge.id, null)).toBe(
         ResponseStatus.OK,
       );
     });
@@ -141,14 +152,14 @@ describe('FightsService', () => {
 
     it('should not start fight without all judges', () => {
       const socket = manager.socket('/');
-      fightService.addJudge(fight.id, fight.mainJudgeId, socket as any);
-      fightService.addJudge(fight.id, fight.redJudgeId, socket as any);
+      fightService.addJudge(fight.id, fight.mainJudge.id, socket as any);
+      fightService.addJudge(fight.id, fight.redJudge.id, socket as any);
       expect(fightService.startFight(fight.id)).toBe(ResponseStatus.NotReady);
     });
 
     it('should start ready fight after missing judge joined', () => {
       const socket = manager.socket('/');
-      fightService.addJudge(fight.id, fight.blueJudgeId, socket as any);
+      fightService.addJudge(fight.id, fight.blueJudge.id, socket as any);
       expect(fightService.startFight(fight.id)).toBe(ResponseStatus.OK);
     });
 
@@ -270,6 +281,99 @@ describe('FightsService', () => {
       expect(fightService.pauseTimer(fight.id, Date.now())).toBe(
         ResponseStatus.BadRequest,
       );
+    });
+  });
+
+  describe('newEvents', () => {
+    let events: Event[];
+    const playerId = fight.redPlayer.id;
+    const playerPoints = 2;
+
+    beforeEach(() => {
+      fight.timer = new Timer(1);
+      fight.state = FightState.Scheduled;
+
+      const socket = manager.socket('/');
+      fightService.addJudge(fight.id, fight.mainJudge.id, socket as any);
+      fightService.addJudge(fight.id, fight.redJudge.id, socket as any);
+      fightService.addJudge(fight.id, fight.blueJudge.id, socket as any);
+      fightService.startFight(fight.id);
+
+      events = [
+        { id: 'a', playerColor: 'red' },
+        { id: 'b', playerColor: 'blue' },
+        { id: 'a', playerColor: 'red' },
+      ];
+    });
+
+    it('should not add events for random fight', () => {
+      expect(
+        fightService.newEvents('test 123', events, playerId, playerPoints),
+      ).toBe(ResponseStatus.NotFound);
+
+      expect(fight.redPlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual([]);
+    });
+
+    it('should not add events for scheduled fight', () => {
+      fight.state = FightState.Scheduled;
+      expect(
+        fightService.newEvents(fight.id, events, playerId, playerPoints),
+      ).toBe(ResponseStatus.BadRequest);
+
+      expect(fight.redPlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual([]);
+    });
+
+    it('should not add events for random player', () => {
+      expect(
+        fightService.newEvents(fight.id, events, 'test 123', playerPoints),
+      ).toBe(ResponseStatus.BadRequest);
+
+      expect(fight.redPlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual([]);
+    });
+
+    it('should not add events for finished fight', () => {
+      fight.state = FightState.Finished;
+      expect(
+        fightService.newEvents(fight.id, events, playerId, playerPoints),
+      ).toBe(ResponseStatus.BadRequest);
+
+      expect(fight.redPlayer.points).toBe(0);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual([]);
+    });
+
+    it('should add new events for running fight', () => {
+      expect(
+        fightService.newEvents(fight.id, events, playerId, playerPoints),
+      ).toBe(ResponseStatus.OK);
+
+      expect(fight.redPlayer.points).toBe(2);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual(events);
+
+      fight.redPlayer.points = 0;
+      fight.bluePlayer.points = 0;
+      fight.eventsHistory = [];
+    });
+
+    it('should add new events for paused fight', () => {
+      expect(
+        fightService.newEvents(fight.id, events, playerId, playerPoints),
+      ).toBe(ResponseStatus.OK);
+
+      expect(fight.redPlayer.points).toBe(2);
+      expect(fight.bluePlayer.points).toBe(0);
+      expect(fight.eventsHistory).toStrictEqual(events);
+
+      fight.redPlayer.points = 0;
+      fight.bluePlayer.points = 0;
+      fight.eventsHistory = [];
     });
   });
 });


### PR DESCRIPTION
Main judge sends (new events list, points for red player, points for blue player) to server -> server updates players state and events history -> server sends to all judges (list of all events, state of blue player, state of red player).

Event is a tuple (id, playerColor) where id is the identifier of the chosen attack/defence/action and playerColor is the 'red' or 'blue' string.

Fight interface has now JudgeState and PlayerState fields instead of multiple simple fields.