### PR TITLE
[RAP-95] Add auto generation of fight id and judges tokens

### DIFF
--- a/server/ENDPOINTS.md
+++ b/server/ENDPOINTS.md
@@ -23,7 +23,7 @@ Existing players are not updated.
 |------|------|
 | -    | JSON |
 
-### Example JSON
+### Example request JSON
 
 ```
 [
@@ -45,11 +45,18 @@ Existing players are not updated.
 ]
 ```
 
+### Example response JSON
+
+```
+["player1", "player3"]
+```
+
 ## `load-fights`
 
 Endpoint takes JSON string as x-www-form-urlencoded body parameter and saves given fights in server. 
-JSON should be an array of `FightData` interface instances. Endpoint returns ids of successfully added fights.
-Existing fights are not updated.
+JSON should be an array of `FightData` interface instances. Server generates unique ids for each fight and
+unique tokens for judges that participate in this fight. If player with given id doesn't exist, the fight
+will not be created. Endpoint returns ids of successfully added fights and judges tokens.
 
 ### Method
 `POST`
@@ -64,15 +71,11 @@ Existing fights are not updated.
 |------|------|
 | -    | JSON |
 
-### Example JSON
+### Example request JSON
 
 ```
 [
   {
-    "id": "fight1",
-    "mainJudgeId": "main",
-    "redJudgeId": "red",
-    "blueJudgeId": "blue",
     "redPlayerId": "player1",
     "bluePlayerId": "player2",
     "endConditions": [
@@ -87,10 +90,6 @@ Existing fights are not updated.
     ]
   },
   {
-    "id": "fight2",
-    "mainJudgeId": "main_judge",
-    "redJudgeId": "red_judge",
-    "blueJudgeId": "blue_judge",
     "redPlayerId": "player3",
     "bluePlayerId": "player2",
     "endConditions": [
@@ -99,7 +98,32 @@ Existing fights are not updated.
         "value": "10"
       }
     ]
+  },
+  {
+    "redPlayerId": "random_player",
+    "bluePlayerId": "player2",
+    "endConditions": []
   }
+]
+```
+
+### Example response JSON
+
+```
+[
+  {
+    "id": "1234567",
+    "mainJudgeId": "9216543",
+    "redJudgeId": "0964892",
+    "blueJudgeId": "0987654"
+  },
+  {
+    "id": "8975645",
+    "mainJudgeId": "1234567",
+    "redJudgeId": "7777777",
+    "blueJudgeId": "0987654"
+  },
+  null
 ]
 ```
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/websockets": "^8.4.4",
         "dotenv": "^16.0.0",
         "mongoose": "^6.0.15",
+        "nanoid": "^3.3.4",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.4.0",
@@ -6883,6 +6884,17 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -14632,6 +14644,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "@nestjs/websockets": "^8.4.4",
     "dotenv": "^16.0.0",
     "mongoose": "^6.0.15",
+    "nanoid": "^3.3.4",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.4.0",
@@ -63,7 +64,10 @@
       "json",
       "ts"
     ],
-    "rootDir": "test",
+    "roots": [
+      "src",
+      "test"
+    ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -3,7 +3,8 @@ import { FightsService } from '../services/fights.service';
 import { PlayersService } from '../services/players.service';
 import { Player } from '../interfaces/player.interface';
 import { ResponseStatus } from '../interfaces/response.interface';
-import { FightDataInterface } from '../interfaces/fight-data.interface';
+import { FightData } from '../interfaces/fight-data.interface';
+import { FightResponse } from '../interfaces/fight-response.interface';
 
 @Controller()
 export class AdminController {
@@ -28,17 +29,36 @@ export class AdminController {
   }
 
   @Post('load-fights')
-  async loadFights(@Body('fights') fightsJson: string): Promise<string[]> {
-    const fights: FightDataInterface[] = JSON.parse(fightsJson);
+  async loadFights(
+    @Body('fights') fightsJson: string,
+  ): Promise<FightResponse[]> {
+    const fights: FightData[] = JSON.parse(fightsJson);
 
-    const successful: string[] = [];
+    const response: FightResponse[] = [];
     await Promise.all(
       fights.map(async (fight) => {
-        if (await this.fightsService.newFightFromData(fight))
-          successful.push(fight.id);
+        if (
+          (await this.playersService.getPlayer(fight.redPlayerId)) == null ||
+          (await this.playersService.getPlayer(fight.bluePlayerId)) == null
+        ) {
+          response.push(undefined);
+          return;
+        }
+
+        const result = await this.fightsService.newFightFromData(fight);
+        if (result !== undefined) {
+          response.push({
+            id: result.id,
+            mainJudgeId: result.mainJudgeId,
+            redJudgeId: result.redJudgeId,
+            blueJudgeId: result.blueJudgeId,
+          });
+        } else {
+          response.push(undefined);
+        }
       }),
     );
 
-    return successful;
+    return response.reverse();
   }
 }

--- a/server/src/interfaces/fight-data.interface.ts
+++ b/server/src/interfaces/fight-data.interface.ts
@@ -1,10 +1,6 @@
 import { FightEndConditionName } from './fight.interface';
 
-export interface FightDataInterface {
-  id: string;
-  mainJudgeId: string;
-  redJudgeId: string;
-  blueJudgeId: string;
+export interface FightData {
   redPlayerId: string;
   bluePlayerId: string;
   endConditions: FightEndCondition[];

--- a/server/src/interfaces/fight-response.interface.ts
+++ b/server/src/interfaces/fight-response.interface.ts
@@ -1,0 +1,6 @@
+export interface FightResponse {
+  id: string;
+  mainJudgeId: string;
+  redJudgeId: string;
+  blueJudgeId: string;
+}

--- a/server/test/services/fights.service.spec.ts
+++ b/server/test/services/fights.service.spec.ts
@@ -153,11 +153,11 @@ describe('FightsService', () => {
   describe('newFightFromData', () => {
     it('should create new fight from FightDataInterface', async () => {
       jest.spyOn(model, 'create').mockImplementationOnce(() => {
-        Promise.resolve(mockFight);
+        Promise.resolve(mockMongoFight);
       });
 
       jest.spyOn(model, 'findOne').mockReturnValue({
-        exec: jest.fn().mockResolvedValueOnce(null),
+        exec: jest.fn().mockResolvedValue(null),
       } as any);
 
       expect(
@@ -176,9 +176,9 @@ describe('FightsService', () => {
 
   describe('getFightFromDb', () => {
     it('should find newly created fight', async () => {
-      jest.spyOn(model, 'create').mockImplementationOnce(() => {
-        Promise.resolve(mockFight);
-      });
+      jest.spyOn(model, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValueOnce(null),
+      } as any);
 
       expect(
         await fightsService.getFightFromDb(mockFight.id),


### PR DESCRIPTION
Serwer automatycznie generuje identyfikator walki oraz tokeny dla sędziów. Są to 7 znakowe napisy złożone z samych cyfr, aby ułatwić wpisywanie tokentów.