### PR TITLE
Rap 109 implementacja przesylania propozycji

### DIFF
--- a/client/public/global.css
+++ b/client/public/global.css
@@ -10,7 +10,7 @@
   --tmg-btn-late: rgb(75, 188, 142);
   --tmg-btn-timing: rgb(3, 149, 144);
   --area-btn-head: rgb(227, 112, 135);
-  --area-btn-body: rgb(255, 136, 106); 
+  --area-btn-body: rgb(255, 136, 106);
   --area-btn-hand: rgb(255, 195, 84);
   font-size: 18px;
 }

--- a/client/src/model/Communication.ts
+++ b/client/src/model/Communication.ts
@@ -1,4 +1,5 @@
 import type { Fighter } from './Fighter';
+import type { Batch } from 'routes/fight/fight-sequence-components/Batch';
 
 export namespace Response {
   export type Color = 'RED' | 'BLUE';
@@ -42,7 +43,7 @@ export namespace Response {
 
   export class Suggestion extends Base {
     judgeColor: Color;
-    events: FightEvent[];
+    events: Batch[];
     redPlayerPoints: number;
     bluePlayerPoints: number;
   }

--- a/client/src/routes/FightSocket.ts
+++ b/client/src/routes/FightSocket.ts
@@ -78,10 +78,6 @@ export class FightSocket {
       }
     };
 
-<<<<<<< HEAD
-    // if (!this.socket.hasListeners(Events.EventsSuggestion))
-=======
->>>>>>> c0268b5 (Final commit)
     this.socket.on(Events.EventsSuggestion, listener);
 
     return [this.#redSuggestion, this.#blueSuggestion];

--- a/client/src/routes/FightSocket.ts
+++ b/client/src/routes/FightSocket.ts
@@ -78,7 +78,10 @@ export class FightSocket {
       }
     };
 
+<<<<<<< HEAD
     // if (!this.socket.hasListeners(Events.EventsSuggestion))
+=======
+>>>>>>> c0268b5 (Final commit)
     this.socket.on(Events.EventsSuggestion, listener);
 
     return [this.#redSuggestion, this.#blueSuggestion];

--- a/client/src/routes/fight/FightPropositionDetails.svelte
+++ b/client/src/routes/fight/FightPropositionDetails.svelte
@@ -1,18 +1,33 @@
 <script lang="ts">
+    import { Label } from "@smui/button";
+    import { createEventDispatcher } from "svelte";
+    import Button from "@smui/button/src/Button.svelte";
     import type { Response } from "model/Communication";
- 
+    import FightSuggestion from "./modal/FightSuggestion.svelte";
+
+    const dispatch = createEventDispatcher();
     export let suggestion: Response.Suggestion;
+    let isOpenModal = false;
+
+    function openModal(suggestion) {
+        dispatch("suggestion");
+        isOpenModal = true;
+    }
+
+    function closeModal() {
+        isOpenModal = false;
+        suggestion = undefined;
+    }
 </script>
 
-{#if suggestion}
+{#if suggestion!==undefined}
     <div class={suggestion.judgeColor.toLowerCase()}>
-        <span class="red-points"> 
-            {suggestion.redPlayerPoints}
-        </span>
-        
-        <span class="blue-points">
-            {suggestion.bluePlayerPoints}
-        </span>
+        <button class="suggestion" 
+                style="background-color: {suggestion.judgeColor.toLowerCase()==="red" ? 'var(--red-fighter)' : 'var(--blue-fighter)'}" 
+                on:click={() => openModal(suggestion)}>
+                Czerwony: {suggestion.redPlayerPoints}, Niebieski: {suggestion.bluePlayerPoints}
+        </button>
+        <FightSuggestion suggestion={suggestion} isOpenModal={isOpenModal} on:closeModal={closeModal} />
     </div>
 {:else}
     <div>
@@ -21,16 +36,14 @@
 {/if}
 
 <style>
-    div.red {
-        border: 1px var(--red-fighter) solid;
+    div.red, div.blue {
+        width: 100%;
     }
 
-    div.blue {
-        border: 1px var(--blue-fighter) solid;
-    }
-
-    span {
+    button.suggestion {
+        width: 100%;
         padding: .125rem .5rem;
+        border-radius: 0.25em;
         color: white;
         text-align: center;
     }

--- a/client/src/routes/fight/FightSideProposition.svelte
+++ b/client/src/routes/fight/FightSideProposition.svelte
@@ -18,6 +18,7 @@
 <style>
   div.side {
     display: flex;
+    height: 20vh;
     align-items: center;
     flex-direction: column;
     gap: 0.5rem;

--- a/client/src/routes/fight/modal/FightPropositionDetails.svelte
+++ b/client/src/routes/fight/modal/FightPropositionDetails.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+    import {createEventDispatcher, getContext} from 'svelte';
+    import Button, { Label } from "@smui/button";
+    import type { Batch } from "../fight-sequence-components/Batch";
+    import { Actions } from "../fight-sequence-components/Actions";
+    import {FightSocket, key} from "../../FightSocket";
+    import { clear } from '../FightSequence.svelte';
+
+    export let points: any;
+    export let stack: Batch[];
+
+    const dispatch = createEventDispatcher();
+    const socket = (getContext(key) as () => FightSocket)();
+
+    export let isOpenModal: boolean;
+
+    function closeModal() {
+        points = {};
+        isOpenModal = false;
+        dispatch('closeModal', { isOpenModal });
+    }
+
+    function confirmPoints(){
+        if (points["red"] != null && points["blue"] != null){
+            socket.sendEvents(points, stack);
+            clear();
+            closeModal();
+        }
+    }
+
+    function choosePoints(point, fighter){
+        points[fighter] = point;
+    }
+</script>
+
+<div id="background" style="--display: {isOpenModal ? 'block' : 'none'};"></div>
+<div id="modal" style="--display: {isOpenModal ? 'block' : 'none'};">
+    <p class="pointsTitle">Propozycja wyników</p>
+    <p>Sekwencja zdarzeń</p>
+    <div class="container">
+        <div class="actions">
+            {#each stack as batch}
+            <span class="action" style="background-color: {batch.colour}">
+                {
+                    Actions.toHumanReadable(batch.action)
+                }
+            </span>
+                <span> &#8594; </span>
+            {/each}
+        </div>
+    </div>
+    <p>Proponowane punkty</p>
+    <div class="pointsDiv">
+        <p>Czerwony: {points['red']}</p>
+        <p>Niebieski: {points['blue']}</p>
+    </div>
+    <div class="buttonDiv">
+        <Button class="bottomButton" id="cancelButton" on:click={closeModal}>
+            <Label>Odrzuć</Label>
+        </Button>
+        <span class="spacer"></span>
+        <Button class="bottomButton" id="confirmButton" on:click={confirmPoints}>
+            <Label>Zatwierdź</Label>
+        </Button>
+    </div>
+
+</div>
+
+<style>
+    #background {
+        display: var(--display);
+        position: fixed;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        background-color: gray;
+        opacity: 0.5;
+    }
+
+    #modal {
+        display: var(--display);
+        position: fixed;
+        z-index: 2;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: #fff;
+        border-style: solid;
+        padding: 1em;
+    }
+
+    div.container {
+        border-top: 1px dimgray solid;
+        padding: 1em;
+        display: flex;
+        justify-content: space-between;
+        flex-direction: column;
+        box-sizing: border-box;
+        height: 36vh;
+        overflow: auto;
+    }
+
+    span.action {
+        font-size: 1em;
+        padding: 0.5em 0.8em;
+        border-radius: 1.5em;
+        margin: 5px 2px;
+        width: max-content;
+        color: white;
+        display: inline-block;
+        position: relative;
+    }
+
+    span:last-child {
+        display: none;
+    }
+
+    p{
+        text-align: center;
+    }
+
+    .pointsTitle{
+        font-weight: bold;
+        font-size: 1.5em;
+    }
+
+    .pointsDiv{
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+        margin: 0.25em;
+    }
+
+    * :global(.pointButton){
+        height: 2.5em;
+        margin: 0 0.5em;
+        padding: 0 1em 0 1em;
+        border-radius: 0.5em;
+        color: white;
+    }
+
+    .buttonDiv{
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+    }
+
+    .spacer{
+        flex: 1 1 auto;
+    }
+
+    * :global(#cancelButton){
+        color: black;
+    }
+
+    * :global(#confirmButton){
+        background-color: #2F4858;
+        color: white;
+    }
+    * :global(.bottomButton){
+        height: 2.5em;
+        margin: 0 0.5em;
+        padding: 0 1em 0 1em;
+        border-radius: 2em;
+    }
+</style>

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,12 +1,11 @@
 {
-
   "extends": "@tsconfig/svelte/tsconfig.json",
 
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*"],
 
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": "./src"
     // "rootDir": "./src"
   }
 }


### PR DESCRIPTION
Komunikacja pomiędzy bocznymi a głównym jest gotowa - back i front są połączone :)

Zauważyłem, że mamy dwa komponenty o nazwie `FightPropositionDetails` - jeden jest oknem modalnym, a drugi składową komponentu `FightSideProposition`. Nie jestem pewien, czy tak miało być, zakładam że jak Krystian tworzył okno modalne dla propozycji to przez przypadek dał taką samą nazwę. Nie powoduje to kolizji nazw, bo są w różnych folderach, ale utrudnia analizę.