### PR TITLE
[RAP-123] Added routing via svelte-spa-router module

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-    import Router from 'svelte-spa-router'
-    import LoginScreen from "./routes/LoginScreen.svelte";
-    import Home from "./routes/Home.svelte";
-    import Organizer from "./routes/Organizer.svelte";
-    import FightSummary from "./routes/fight/modal/FightSummary.svelte";
+  import Router from 'svelte-spa-router';
+  import LoginScreen from './routes/LoginScreen.svelte';
+  import Home from './routes/Home.svelte';
+  import Organizer from './routes/Organizer.svelte';
+  import FightSummary from './routes/fight/modal/FightSummary.svelte';
 
-    const routes = {
-        '/' : Home,
-        '/fight' : LoginScreen,
-        '/organizer' : Organizer,
-        '/summary' : FightSummary,
-        '*' : Home,
-    }
+  const routes = {
+    '/': Home,
+    '/fight': LoginScreen,
+    '/organizer': Organizer,
+    '/summary': FightSummary,
+    '*': Home,
+  };
 </script>
 
-<Router {routes}/>
+<Router {routes} />

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
+    import Router from 'svelte-spa-router'
     import LoginScreen from "./routes/LoginScreen.svelte";
+    import Home from "./routes/Home.svelte";
+    import Organizer from "./routes/Organizer.svelte";
+    import FightSummary from "./routes/fight/modal/FightSummary.svelte";
+
+    const routes = {
+        '/' : Home,
+        '/fight' : LoginScreen,
+        '/organizer' : Organizer,
+        '/summary' : FightSummary,
+        '*' : Home,
+    }
 </script>
 
-<LoginScreen/>
+<Router {routes}/>

--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -4,10 +4,12 @@
   import Home from './routes/Home.svelte';
   import Organizer from './routes/Organizer.svelte';
   import FightSummary from './routes/fight/modal/FightSummary.svelte';
+  import FightStart from './routes/FightStart.svelte';
 
   const routes = {
     '/': Home,
-    '/fight': LoginScreen,
+    '/login': LoginScreen,
+    '/fight/:fightId/:judgeId': FightStart,
     '/organizer': Organizer,
     '/summary': FightSummary,
     '*': Home,

--- a/client/src/routes/FightStart.svelte
+++ b/client/src/routes/FightStart.svelte
@@ -3,7 +3,7 @@
   import { Events, FightSocket, key } from './FightSocket';
   import { getContext } from 'svelte';
   import type { Response } from 'model/Communication';
-  import {push} from 'svelte-spa-router';
+  import { push } from 'svelte-spa-router';
 
   export let response: Response.Join;
   let startPointSync = 0;
@@ -21,7 +21,7 @@
   socket.on(Events.FinishFight, (response: Response.Status) => {
     if (response['status'] == 'OK') {
       fightState = FightState.Finished;
-      push("/summary");
+      push('/summary');
     }
   });
 

--- a/client/src/routes/FightStart.svelte
+++ b/client/src/routes/FightStart.svelte
@@ -3,7 +3,7 @@
   import { Events, FightSocket, key } from './FightSocket';
   import { getContext } from 'svelte';
   import type { Response } from 'model/Communication';
-  import FightSummary from './fight/modal/FightSummary.svelte';
+  import {push} from 'svelte-spa-router';
 
   export let response: Response.Join;
   let startPointSync = 0;
@@ -21,6 +21,7 @@
   socket.on(Events.FinishFight, (response: Response.Status) => {
     if (response['status'] == 'OK') {
       fightState = FightState.Finished;
+      push("/summary");
     }
   });
 
@@ -37,9 +38,6 @@
 </script>
 
 {#if fightState === FightState.Waiting}
-  <!--  TODO: Fight creation -->
-  <!-- <CreateFight /> -->
-
   {#if response.role === 'MAIN'}
     <div class="start">
       <button on:click={handleClick} class="startButton">
@@ -53,8 +51,6 @@
   {/if}
 {:else if fightState === FightState.Started}
   <Fight {...response} start={startPointSync} />
-{:else if fightState === FightState.Finished}
-  <FightSummary />
 {/if}
 
 <style>

--- a/client/src/routes/Home.svelte
+++ b/client/src/routes/Home.svelte
@@ -6,7 +6,7 @@
   }
 
   function navigateFight() {
-    push('/fight');
+    push('/login');
   }
 </script>
 

--- a/client/src/routes/Home.svelte
+++ b/client/src/routes/Home.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import {push} from 'svelte-spa-router'
+
+    function navigateOrganizer(){
+        push("/organizer")
+    }
+
+    function navigateFight(){
+        push("/fight")
+    }
+</script>
+
+<div class="home">
+    <button on:click={navigateFight}> Walka </button>
+    <button on:click={navigateOrganizer}> Organizator </button>
+</div>
+
+<style>
+    div.home {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        background-image: url('../resources/fightstart_background_semitransparent.png');
+        background-repeat: repeat;
+    }
+
+    button {
+        border: 1px black solid;
+        font-size: 2rem;
+    }
+
+</style>

--- a/client/src/routes/Home.svelte
+++ b/client/src/routes/Home.svelte
@@ -1,35 +1,34 @@
 <script lang="ts">
-    import {push} from 'svelte-spa-router'
+  import { push } from 'svelte-spa-router';
 
-    function navigateOrganizer(){
-        push("/organizer")
-    }
+  function navigateOrganizer() {
+    push('/organizer');
+  }
 
-    function navigateFight(){
-        push("/fight")
-    }
+  function navigateFight() {
+    push('/fight');
+  }
 </script>
 
 <div class="home">
-    <button on:click={navigateFight}> Walka </button>
-    <button on:click={navigateOrganizer}> Organizator </button>
+  <button on:click={navigateFight}> Walka </button>
+  <button on:click={navigateOrganizer}> Organizator </button>
 </div>
 
 <style>
-    div.home {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        justify-content: center;
-        align-items: center;
-        min-height: 100vh;
-        background-image: url('../resources/fightstart_background_semitransparent.png');
-        background-repeat: repeat;
-    }
+  div.home {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-image: url('../resources/fightstart_background_semitransparent.png');
+    background-repeat: repeat;
+  }
 
-    button {
-        border: 1px black solid;
-        font-size: 2rem;
-    }
-
+  button {
+    border: 1px black solid;
+    font-size: 2rem;
+  }
 </style>

--- a/client/src/routes/LoginScreen.svelte
+++ b/client/src/routes/LoginScreen.svelte
@@ -1,46 +1,26 @@
 <script lang="ts">
-  import FightStart from './FightStart.svelte';
-  import { FightSocket, key } from './FightSocket';
-  import { setContext } from 'svelte';
+  import { push } from 'svelte-spa-router';
 
   let fightId = '';
   let judgeId = '';
-  let socket: FightSocket;
-
-  setContext(key, () => socket);
 
   function enterData() {
-    console.log(fightId, judgeId);
-    socket = new FightSocket(fightId.trim(), judgeId.trim());
-    enteredData = true;
+    push('/fight/' + fightId.trim() + '/' + judgeId.trim());
   }
-
-  let enteredData = false;
 </script>
 
-{#if !enteredData}
-  <div class="login">
-    <fieldset>
-      <legend>Identyfikator walki</legend>
-      <input bind:value={fightId}/>
-    </fieldset>
-    <fieldset>
-      <legend>Identyfikator sędziego</legend>
-      <input bind:value={judgeId}/>
-    </fieldset>
+<div class="login">
+  <fieldset>
+    <legend>Identyfikator walki</legend>
+    <input bind:value={fightId} />
+  </fieldset>
+  <fieldset>
+    <legend>Identyfikator sędziego</legend>
+    <input bind:value={judgeId} />
+  </fieldset>
 
-    <button on:click={enterData}> Wejdź </button>
-  </div>
-{:else}
-  {#await socket.join()}
-    <!-- Bez styli! -->
-    <p>Oczekuję na połączenie...</p>
-  {:then response}
-    <FightStart {response} />
-  {:catch err}
-    <p>Error: {err}</p>
-  {/await}
-{/if}
+  <button on:click={enterData}> Wejdź </button>
+</div>
 
 <style>
   div.login {

--- a/client/src/routes/Organizer.svelte
+++ b/client/src/routes/Organizer.svelte
@@ -1,0 +1,16 @@
+<div class="organizer">
+    <p style="background-color: lightgray">Hello there, Organizer Kenobi</p>
+</div>
+
+<style>
+    div.organizer {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+        background-image: url('../resources/fightstart_background_semitransparent.png');
+        background-repeat: repeat;
+    }
+</style>

--- a/client/src/routes/Organizer.svelte
+++ b/client/src/routes/Organizer.svelte
@@ -1,16 +1,16 @@
 <div class="organizer">
-    <p style="background-color: lightgray">Hello there, Organizer Kenobi</p>
+  <p style="background-color: lightgray">Hello there, Organizer Kenobi</p>
 </div>
 
 <style>
-    div.organizer {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        justify-content: center;
-        align-items: center;
-        min-height: 100vh;
-        background-image: url('../resources/fightstart_background_semitransparent.png');
-        background-repeat: repeat;
-    }
+  div.organizer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-image: url('../resources/fightstart_background_semitransparent.png');
+    background-repeat: repeat;
+  }
 </style>

--- a/client/src/routes/fight/modal/FightSummary.svelte
+++ b/client/src/routes/fight/modal/FightSummary.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import { getContext } from 'svelte';
-  import { FightSocket, key } from '../../FightSocket';
-
-  const socket = (getContext(key) as () => FightSocket)();
+    import {replace} from "svelte-spa-router";
 
     function leave(){
-        socket.close();
-        window.location.reload();
+        replace("/fight")
     }
 </script>
 

--- a/client/src/routes/fight/modal/FightSummary.svelte
+++ b/client/src/routes/fight/modal/FightSummary.svelte
@@ -2,7 +2,7 @@
   import { replace } from 'svelte-spa-router';
 
   function leave() {
-    replace('/fight');
+    replace('/');
   }
 </script>
 

--- a/client/src/routes/fight/modal/FightSummary.svelte
+++ b/client/src/routes/fight/modal/FightSummary.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-    import {replace} from "svelte-spa-router";
+  import { replace } from 'svelte-spa-router';
 
-    function leave(){
-        replace("/fight")
-    }
+  function leave() {
+    replace('/fight');
+  }
 </script>
 
 <div class="summary">
-    <p>Walka zakończona!</p>
-    <button on:click={leave}>Wyjdź</button>
+  <p>Walka zakończona!</p>
+  <button on:click={leave}>Wyjdź</button>
 </div>
 
 <style>


### PR DESCRIPTION
Dodałem dwa nowe ekrany: ekran główny (Home) oraz ekran organizatora (Organizer, na razie placeholderowy). Wykorzystałem moduł svelte-spa-router i routing wygląda aktualnie tak że:
- "/" oraz pozostałe przekierowuje na ekran główny
- "/summary" to ścieżka prowadząca do ekranu podsumowania, nie ma już problemu zapętlenia
- "/organizer" to ścieżka do ekranu organizatora
- "/fight" to ścieżka do ekranu logowania do walki, sama walka dalej jest jako nested component w logowaniu, bo nie wiedziałem w jaki sposób przekazać teraz dane z FightStart do Fight (tzn. response po odebraniu JOIN oraz start do synchronizacji), ale wydaje mi się, że na ten etap taka nawigacja może pozostać